### PR TITLE
Use sorted map for processing nestedexpression expressions

### DIFF
--- a/src/main/java/io/github/linuxforhealth/hl7/expression/NestedExpression.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/expression/NestedExpression.java
@@ -5,11 +5,7 @@
  */
 package io.github.linuxforhealth.hl7.expression;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 import org.slf4j.Logger;
@@ -40,8 +36,11 @@ public class NestedExpression extends AbstractExpression {
 
   public NestedExpression(ExpressionAttributes attr) {
     super(attr);
-    this.childexpressions = new HashMap<>();
     if (attr.getExpressions() != null) {
+      // Use a TreeMap here since it implements the SortedMap interface
+      // to guarantee that the keys can be accessed in the order the array is
+      // in the schema
+      this.childexpressions = new TreeMap<>();
       int index = 0;
       for (ExpressionAttributes nestedattrs : attr.getExpressions()) {
         Expression e = HL7DataBasedResourceDeserializer.generateExpression(nestedattrs);
@@ -53,7 +52,7 @@ public class NestedExpression extends AbstractExpression {
 
       this.generateMap = false;
     } else if (attr.getExpressionsMap() != null) {
-
+      this.childexpressions = new HashMap<>();
       for (Entry<String, ExpressionAttributes> nestedattrs : attr.getExpressionsMap().entrySet()) {
         Expression e = HL7DataBasedResourceDeserializer.generateExpression(nestedattrs.getValue());
         if (e != null) {

--- a/src/main/java/io/github/linuxforhealth/hl7/resource/ResourceEvaluationResult.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/resource/ResourceEvaluationResult.java
@@ -1,9 +1,7 @@
 package io.github.linuxforhealth.hl7.resource;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+
 import io.github.linuxforhealth.api.ResourceValue;
 
 public class ResourceEvaluationResult {
@@ -28,7 +26,7 @@ public class ResourceEvaluationResult {
       List<ResourceValue> additionalResolveValues, PendingExpressionState pendingExpressions) {
     this.additionalResolveValues = new ArrayList<>();
     this.additionalResolveValues.addAll(additionalResolveValues);
-    this.resolveValues = new HashMap<>();
+    this.resolveValues = new TreeMap<>();
     this.resolveValues.putAll(resolveValues);
     this.pendingExpressions = pendingExpressions;
   }

--- a/src/main/java/io/github/linuxforhealth/hl7/util/ExpressionUtility.java
+++ b/src/main/java/io/github/linuxforhealth/hl7/util/ExpressionUtility.java
@@ -5,12 +5,8 @@
  */
 package io.github.linuxforhealth.hl7.util;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -61,7 +57,7 @@ public class ExpressionUtility {
             localContext.put(Constants.NULL_VAR_NAME, new EmptyEvaluationResult());
             // initialize the map and list to collect values
             List<ResourceValue> additionalResolveValues = new ArrayList<>();
-            Map<String, Object> resolveValues = new HashMap<>();
+            Map<String, Object> resolveValues = new TreeMap<>();
 
             for (Entry<String, Expression> entry : expressionMap.entrySet()) {
 


### PR DESCRIPTION
This solves the issue where an array of expressions were not guaranteed to generate an array in the same order as specified in the schema